### PR TITLE
Update IERC20.sol

### DIFF
--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -12,6 +12,14 @@ interface IERC20 {
         returns (uint256);
 
     function approve(address spender, uint256 amount) external returns (bool);
+    
+    function transfer(address recipient, uint256 amount) external returns (bool);
+    
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(


### PR DESCRIPTION
Added complete IERC20 functions.

Reason:
BoringBatchable is implementing IERC20, any contracts that import HelloBentoBox contract are automatically also importing this IERC20.  Since this IERC20 is not complete, some functions(transfer & transferFrom) are not recognizable.